### PR TITLE
TD-1397 Fixed issue in mobile view for longer validation message

### DIFF
--- a/NHSUKViewComponents.Web/Views/Shared/Components/TextInput/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/TextInput/Default.cshtml
@@ -1,7 +1,7 @@
 ﻿@using NHSUKViewComponents.Web.ViewModels
 @using NHSUKViewComponents.Web.Helpers
 @model TextInputViewModel
-<div class="nhsuk-form-group @(Model.HasError ? "nhsuk-form-group--error" : "")" style="white-space:nowrap">
+<div class="nhsuk-form-group @(Model.HasError ? "nhsuk-form-group--error" : "")">
     <label class="nhsuk-label" for="@Model.Name">
         @Model.Label
     </label>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1397

### Description
There is a issue in Mobile view when there is any long error validation msg showing on the below screens. This is caused by the textinput view component having a css style which is not required. 

### Screenshots
![WavePlugin](https://user-images.githubusercontent.com/111436026/235097412-0dc1c28b-1ba5-4aeb-af8f-45baeaf33cb2.png)
![Error-Register-Digital-Learning-Solutions](https://user-images.githubusercontent.com/111436026/235097418-524fc395-7771-419b-8e1a-4a4d1be7caa0.png)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
