### PR TITLE
TD-1278 - fixed spacing issue by adding class  field-validation-valid

### DIFF
--- a/NHSUKViewComponents.Web/Views/Shared/Components/NumericInput/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/NumericInput/Default.cshtml
@@ -25,7 +25,7 @@
 
     @if(!Model.HasError)
     {
-        <div data-valmsg-for="@Model.Name" data-valmsg-replace="true" class="nhsuk-error-message nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
+        <div data-valmsg-for="@Model.Name" data-valmsg-replace="true" class="nhsuk-error-message field-validation-valid nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
         </div>
     }
 

--- a/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
@@ -21,7 +21,7 @@
 
     @if (Model.Required)
     {
-        <div data-valmsg-for="@Model.AspFor" data-valmsg-replace="true" class="nhsuk-error-message nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
+            <div data-valmsg-for="@Model.AspFor" data-valmsg-replace="true" class="nhsuk-error-message field-validation-valid nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
         </div>
     }
 

--- a/NHSUKViewComponents.Web/Views/Shared/Components/SelectList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/SelectList/Default.cshtml
@@ -20,7 +20,7 @@
     }
     @if (Model.Required && !Model.HasError)
     {
-        <div data-valmsg-for="@Model.Name" data-valmsg-replace="true" class="nhsuk-error-message nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">            
+        <div data-valmsg-for="@Model.Name" data-valmsg-replace="true" class="nhsuk-error-message field-validation-valid nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
         </div>
     }
     <select class="nhsuk-select @Model.Class @(Model.HasError ? "nhsuk-input--error" : "")"

--- a/NHSUKViewComponents.Web/Views/Shared/Components/TextArea/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/TextArea/Default.cshtml
@@ -32,7 +32,7 @@
     }
     @if (Model.CharacterCount.HasValue && !Model.HasError)        
     {
-        <div data-valmsg-for="@Model.Name" data-valmsg-replace="true" class="nhsuk-error-message nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">           
+        <div data-valmsg-for="@Model.Name" data-valmsg-replace="true" class="nhsuk-error-message field-validation-valid nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
         </div>
     }
 

--- a/NHSUKViewComponents.Web/Views/Shared/Components/TextInput/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/TextInput/Default.cshtml
@@ -24,7 +24,7 @@
     }
     @if (Model.Required && !Model.HasError)
     {
-        <div data-valmsg-for="@Model.Name" data-valmsg-replace="true" class="nhsuk-error-message nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">           
+        <div data-valmsg-for="@Model.Name" data-valmsg-replace="true" class="nhsuk-error-message field-validation-valid nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">           
         </div>
     }
 


### PR DESCRIPTION
### JIRA link
TD-1278

### Description
Jquey validation was adding extra div tag spacing on valid input, added field-validation-valid class to error message div to remvoe extra spacing

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
