### PR TITLE
TD-1682  addition of  nhsuk-u-reading-width class to the error summary div.

### DIFF
--- a/NHSUKViewComponents.Web/Views/Shared/Components/ErrorSummary/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/ErrorSummary/Default.cshtml
@@ -3,7 +3,7 @@
 
 @if(Model.Errors.Any())
 {
-    <div class="nhsuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+    <div class="nhsuk-error-summary nhsuk-u-reading-width" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
       <h2 class="nhsuk-error-summary__title" id="error-summary-title">
         There is a problem
       </h2>
@@ -21,7 +21,7 @@
 }
 else
 {
-    <div class="nhsuk-error-summary validation-summary-errors validation-summary-valid" data-valmsg-summary="true" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+    <div class="nhsuk-error-summary validation-summary-errors validation-summary-valid nhsuk-u-reading-width" data-valmsg-summary="true" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
         <h2 class="nhsuk-error-summary__title" id="error-summary-title">
             There is a problem
         </h2>


### PR DESCRIPTION

### JIRA link
[TD-1682 ](https://hee-tis.atlassian.net/browse/TD-1682)

### Description
modification of the component package to add the nhsuk-u-reading-width class to the nhsuk-error-summary div to ensure content and error summary border does not exceed the reading width.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
