### PR TITLE
TD-1855: Optional radio and checkbox  item css

### DIFF
--- a/NHSUKViewComponents.Web/ViewComponents/CheckboxesViewComponent.cs
+++ b/NHSUKViewComponents.Web/ViewComponents/CheckboxesViewComponent.cs
@@ -13,7 +13,8 @@
             bool populateWithCurrentValues,
             string? errormessage,
             string? hintText,
-            bool required
+            bool required,
+            string cssClass = default
         )
         {
             var checkboxList = checkboxes.Select(
@@ -32,7 +33,8 @@
                 string.IsNullOrEmpty(hintText) ? null : hintText,
                 errormessage,
                 checkboxList,
-                required
+                required,
+                string.IsNullOrEmpty(cssClass) ? null : cssClass
             );
 
             return View(viewModel);

--- a/NHSUKViewComponents.Web/ViewComponents/RadioListViewComponent.cs
+++ b/NHSUKViewComponents.Web/ViewComponents/RadioListViewComponent.cs
@@ -15,9 +15,15 @@
             bool populateWithCurrentValues,
             string hintText,
             bool required,
-            string? requiredClientSideErrorMessage = default
+            string? requiredClientSideErrorMessage = default,
+            string cssClass = default
         )
         {
+            var model = ViewData.Model;
+            var property = model.GetType().GetProperty(aspFor);
+            var errorMessages = ViewData.ModelState[property?.Name]?.Errors.Select(e => e.ErrorMessage) ??
+                                new string[] { };
+
             var radiosList = radios.Select(
                 r => new RadiosItemViewModel(
                     r.Value,
@@ -32,8 +38,10 @@
                 label,
                 string.IsNullOrEmpty(hintText) ? null : hintText,
                 radiosList,
+                errorMessages,
                 required,
-                string.IsNullOrEmpty(requiredClientSideErrorMessage) ? null : requiredClientSideErrorMessage
+                string.IsNullOrEmpty(requiredClientSideErrorMessage) ? null : requiredClientSideErrorMessage,
+                string.IsNullOrEmpty(cssClass) ? null : cssClass
             );
 
             return View(viewModel);

--- a/NHSUKViewComponents.Web/ViewModels/CheckboxesViewModel.cs
+++ b/NHSUKViewComponents.Web/ViewModels/CheckboxesViewModel.cs
@@ -9,7 +9,8 @@
             string? hintText,
             string? errormessage,
             IEnumerable<CheckboxItemViewModel> checkboxes,
-            bool required = false
+            bool required = false,
+            string? cssClass = default
         )
         {
             Label = label;
@@ -17,11 +18,14 @@
             Checkboxes = checkboxes;
             ErrorMessage = errormessage;
             Required = required;
+            Class = cssClass;
         }
 
         public string Label { get; set; }
 
         public string? HintText { get; set; }
+
+        public string? Class { get; set; }
 
         public string? ErrorMessage { get; set; }
 

--- a/NHSUKViewComponents.Web/ViewModels/RadiosViewModel.cs
+++ b/NHSUKViewComponents.Web/ViewModels/RadiosViewModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace NHSUKViewComponents.Web.ViewModels
 {
     using System.Collections.Generic;
+    using System.Linq;
 
     public class RadiosViewModel
     {
@@ -9,16 +10,22 @@
             string label,
             string hintText,
             IEnumerable<RadiosItemViewModel> radios,
+            IEnumerable<string> errorMessages,
             bool required,
-            string? requiredClientSideErrorMessage = default
+            string? requiredClientSideErrorMessage = default,
+            string? cssClass = default
         )
         {
+            var errorMessageList = errorMessages.ToList();
             AspFor = aspFor;
             Label = !required && !label.EndsWith("(optional)") ? label + " (optional)" : label;
             HintText = hintText;
             Radios = radios;
+            ErrorMessages = errorMessageList;
+            HasError = errorMessageList.Any();
             Required = required;
             RequiredClientSideErrorMessage = requiredClientSideErrorMessage;
+            Class = cssClass;
         }
 
         public string AspFor { get; set; }
@@ -26,6 +33,9 @@
         public string Label { get; set; }
 
         public string HintText { get; set; }
+        public string? Class { get; set; }
+        public IEnumerable<string> ErrorMessages { get; set; }
+        public readonly bool HasError;
 
         public IEnumerable<RadiosItemViewModel> Radios { get; set; }
         public bool Required { get; set; }

--- a/NHSUKViewComponents.Web/Views/Shared/Components/Checkboxes/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/Checkboxes/Default.cshtml
@@ -31,7 +31,17 @@
         <div class="nhsuk-checkboxes">
             @foreach (var checkbox in Model.Checkboxes)
             {
-                <partial name="_CheckboxItem" model="checkbox" />
+                if (!string.IsNullOrWhiteSpace(Model.Class))
+                {
+                    <div class="@Model.Class">
+                        <partial name="_CheckboxItem" model="checkbox" />
+                    </div>
+                }
+                else
+                {
+                    <partial name="_CheckboxItem" model="checkbox" />
+                }
+
             }
         </div>
     </fieldset>

--- a/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
@@ -3,55 +3,96 @@
 
 @model RadiosViewModel
 
-<div class="nhsuk-form-group">
+<div class="nhsuk-form-group @(Model.HasError ? "nhsuk-form-group--error" : "")">
 
-  <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Label.RemoveWhitespace()-hint">
-    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
-      <label class="nhsuk-fieldset__heading">
-        @Model.Label
-      </label>
-    </legend>
+    <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Label.RemoveWhitespace()-hint">
+        <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
+            <label class="nhsuk-fieldset__heading">
+                @Model.Label
+            </label>
+        </legend>
 
-    @if (Model.HintText != null)
-    {
-      <div class="nhsuk-hint" id="@Model.Label.RemoveWhitespace()-hint">
-        @Html.Raw(Model.HintText)
-      </div>
-    }   
-
-    @if (Model.Required)
-    {
-            <div data-valmsg-for="@Model.AspFor" data-valmsg-replace="true" class="nhsuk-error-message field-validation-valid nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
-        </div>
-    }
-
-    <div class="nhsuk-radios" aria-required="@(Model.Required ? "true" : "false" )">
-      @foreach (var (radio, index) in Model.Radios.Select((r, i) => (r, i)))
-      {
-        var radioId = $"{radio.Value}-{index}";
-        <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input"
-               id="@radioId"
-               name="@Model.AspFor"
-               type="radio"
-               value="@radio.Value"
-               aria-describedby="@radio.Value-item-hint"
-               data-val-required="@(Model.Required ? Model.RequiredClientSideErrorMessage : "" )"
-               data-val="@(Model.Required ? "true" : "false" )"
-               @(radio.Selected ? "checked" : string.Empty) />
-          <label class="nhsuk-label nhsuk-radios__label" for="@radioId">
-            @radio.Label
-          </label>
-          @if (radio.HintText != null)
-          {
-            <div class="nhsuk-hint nhsuk-radios__hint" id="@radio.Value-item-hint">
-              @radio.HintText
+        @if (Model.HintText != null)
+        {
+            <div class="nhsuk-hint" id="@Model.Label.RemoveWhitespace()-hint">
+                @Html.Raw(Model.HintText)
             </div>
-          }
-        </div>
-      }
+        }
 
-    </div>
-  </fieldset>
+        @if (Model.HasError)
+        {
+            <div id="@Model.AspFor-error" class="nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
+                @foreach (var errorMessage in Model.ErrorMessages)
+                {
+                    <span class="error-message--margin-bottom-1 nhsuk-error-message">
+                        <span class="nhsuk-u-visually-hidden">Error:</span> @errorMessage
+                    </span>
+                }
+            </div>
+        }
+
+        @if (Model.Required && !Model.HasError)
+        {
+            <div data-valmsg-for="@Model.AspFor" data-valmsg-replace="true" class="nhsuk-error-message field-validation-valid nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-3">
+            </div>
+        }
+
+        <div class="nhsuk-radios" aria-required="@(Model.Required ? "true" : "false" )">
+            @foreach (var (radio, index) in Model.Radios.Select((r, i) => (r, i)))
+            {
+                var radioId = $"{radio.Value}-{index}";
+                if (!string.IsNullOrWhiteSpace(Model.Class))
+                {
+                    <div class="@Model.Class">
+                        <div class="nhsuk-radios__item">
+                            <input class="nhsuk-radios__input"
+                           id="@radioId"
+                           name="@Model.AspFor"
+                           type="radio"
+                           value="@radio.Value"
+                           aria-describedby="@radio.Value-item-hint"
+                           data-val-required="@(Model.Required ? Model.RequiredClientSideErrorMessage : "" )"
+                           data-val="@(Model.Required ? "true" : "false" )"
+                           @(radio.Selected ? "checked" : string.Empty) />
+                            <label class="nhsuk-label nhsuk-radios__label" for="@radioId">
+                                @radio.Label
+                            </label>
+                            @if (radio.HintText != null)
+                            {
+                                <div class="nhsuk-hint nhsuk-radios__hint" id="@radio.Value-item-hint">
+                                    @radio.HintText
+                                </div>
+                            }
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <div class="nhsuk-radios__item">
+                        <input class="nhsuk-radios__input"
+                       id="@radioId"
+                       name="@Model.AspFor"
+                       type="radio"
+                       value="@radio.Value"
+                       aria-describedby="@radio.Value-item-hint"
+                       data-val-required="@(Model.Required ? Model.RequiredClientSideErrorMessage : "" )"
+                       data-val="@(Model.Required ? "true" : "false" )"
+                       @(radio.Selected ? "checked" : string.Empty) />
+                        <label class="nhsuk-label nhsuk-radios__label" for="@radioId">
+                            @radio.Label
+                        </label>
+                        @if (radio.HintText != null)
+                        {
+                            <div class="nhsuk-hint nhsuk-radios__hint" id="@radio.Value-item-hint">
+                                @radio.HintText
+                            </div>
+                        }
+                    </div>
+                }
+
+            }
+
+        </div>
+    </fieldset>
 
 </div>


### PR DESCRIPTION
### JIRA link
[TD-1855](https://hee-tis.atlassian.net/browse/TD-1855)

### Description
Added optional CSS property to radiolist and checkboxes view components in other to even distribute child items horizontally in divs.
Added span with class="nhsuk-error-message" for validation error within the radiolist view component.

### Screenshots
![radio and checkbox](https://github.com/TechnologyEnhancedLearning/NHSDesignSystemViewComponents/assets/114475132/a1cf1858-01f0-43dd-8bc4-caa2e57c7b04)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1855]: https://hee-tis.atlassian.net/browse/TD-1855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ