### PR TITLE
TD-1871 Extend NHSUK view component radio list to accept optional radio item

### DIFF
--- a/NHSUKViewComponents.Web/ViewComponents/DateInputViewComponent.cs
+++ b/NHSUKViewComponents.Web/ViewComponents/DateInputViewComponent.cs
@@ -18,6 +18,7 @@
         /// <param name="yearId"></param>
         /// <param name="cssClass">Leave blank for no custom css class.</param>
         /// <param name="hintTextLines">Leave blank for no hint.</param>
+        /// <param name="isPageHeading">Leave blank/false for set label as page body .</param>
         /// <returns></returns>
         public IViewComponentResult Invoke(
             string id,
@@ -26,7 +27,8 @@
             string monthId,
             string yearId,
             string cssClass,
-            IEnumerable<string>? hintTextLines
+            IEnumerable<string>? hintTextLines,
+            bool? isPageHeading = false
         )
         {
             var model = ViewData.Model;
@@ -59,7 +61,8 @@
                 yearErrors?.Count > 0,
                 nonEmptyErrors,
                 string.IsNullOrEmpty(cssClass) ? null : cssClass,
-                hintTextLines.Any() ? hintTextLines : null
+                hintTextLines.Any() ? hintTextLines : null,
+                isPageHeading
             );
             return View(viewModel);
         }

--- a/NHSUKViewComponents.Web/ViewComponents/RadioListViewComponent.cs
+++ b/NHSUKViewComponents.Web/ViewComponents/RadioListViewComponent.cs
@@ -16,7 +16,8 @@
             string hintText,
             bool required,
             string? requiredClientSideErrorMessage = default,
-            string cssClass = default
+            string cssClass = default,
+            string? optionalRadio = default
         )
         {
             var model = ViewData.Model;
@@ -24,7 +25,7 @@
             var errorMessages = ViewData.ModelState[property?.Name]?.Errors.Select(e => e.ErrorMessage) ??
                                 new string[] { };
 
-            var radiosList = radios.Select(
+            var radiosList = radios.Where(x=>x.Label != optionalRadio).Select(
                 r => new RadiosItemViewModel(
                     r.Value,
                     r.Label,
@@ -32,12 +33,16 @@
                     r.HintText
                 )
             );
+            
 
             var viewModel = new RadiosViewModel(
                 aspFor,
                 label,
                 string.IsNullOrEmpty(hintText) ? null : hintText,
                 radiosList,
+                string.IsNullOrEmpty(optionalRadio) ? null : radios.Where(x => x.Label == optionalRadio)
+                                                                   .Select(r => new RadiosItemViewModel(r.Value, r.Label, IsSelectedRadio(aspFor, r, populateWithCurrentValues), r.HintText))
+                                                                   .FirstOrDefault(),
                 errorMessages,
                 required,
                 string.IsNullOrEmpty(requiredClientSideErrorMessage) ? null : requiredClientSideErrorMessage,

--- a/NHSUKViewComponents.Web/ViewModels/DateInputViewModel.cs
+++ b/NHSUKViewComponents.Web/ViewModels/DateInputViewModel.cs
@@ -22,7 +22,8 @@
             bool hasYearError,
             IEnumerable<string> errorMessages,
             string? cssClass = null,
-            IEnumerable<string>? hintTextLines = null
+            IEnumerable<string>? hintTextLines = null,
+            bool? isPageHeading = false
         )
         {
             Id = id;
@@ -35,6 +36,7 @@
             YearValue = yearValue;
             CssClass = cssClass;
             HintTextLines = hintTextLines;
+            IsPageHeading = isPageHeading;
             HasDayError = hasDayError;
             HasMonthError = hasMonthError;
             HasYearError = hasYearError;
@@ -51,6 +53,8 @@
         public string? YearValue { get; set; }
         public string? CssClass { get; set; }
         public IEnumerable<string>? HintTextLines { get; set; }
+        public bool? IsPageHeading { get; set; }
+
         public bool HasError => HasDayError || HasMonthError || HasYearError;
         public IEnumerable<string> ErrorMessages { get; set; }
     }

--- a/NHSUKViewComponents.Web/ViewModels/RadiosViewModel.cs
+++ b/NHSUKViewComponents.Web/ViewModels/RadiosViewModel.cs
@@ -10,6 +10,7 @@
             string label,
             string hintText,
             IEnumerable<RadiosItemViewModel> radios,
+            RadiosItemViewModel optionalRadio,
             IEnumerable<string> errorMessages,
             bool required,
             string? requiredClientSideErrorMessage = default,
@@ -21,6 +22,7 @@
             Label = !required && !label.EndsWith("(optional)") ? label + " (optional)" : label;
             HintText = hintText;
             Radios = radios;
+            OptionalRadio = optionalRadio;
             ErrorMessages = errorMessageList;
             HasError = errorMessageList.Any();
             Required = required;
@@ -38,6 +40,7 @@
         public readonly bool HasError;
 
         public IEnumerable<RadiosItemViewModel> Radios { get; set; }
+        public RadiosItemViewModel OptionalRadio { get; set; }
         public bool Required { get; set; }
         public string RequiredClientSideErrorMessage { get; set; }
     }

--- a/NHSUKViewComponents.Web/Views/Shared/Components/DateInput/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/DateInput/Default.cshtml
@@ -10,8 +10,18 @@
 
 <div class="@Model.CssClass @errorCss" id="@Model.Id">
   <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Id-hint" role="group">
-    <legend class="nhsuk-fieldset__legend nhsuk-label">
-      @Model.Label
+        <legend class="nhsuk-fieldset__legend @(Model.IsPageHeading.GetValueOrDefault() ? "nhsuk-fieldset__legend--l":"nhsuk-label")">
+        @if(Model.IsPageHeading.GetValueOrDefault()==true)
+        {
+            <h1 class="nhsuk-fieldset__heading">
+                @Model.Label
+            </h1>
+        }
+        else
+        {
+              @Model.Label
+        }
+
     </legend>
     @if (Model.HintTextLines != null) {
       @foreach (var hintText in Model.HintTextLines) {

--- a/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
@@ -2,6 +2,10 @@
 @using NHSUKViewComponents.Web.ViewModels
 
 @model RadiosViewModel
+@{
+    int counter = 0;
+    
+}
 
 <div class="nhsuk-form-group @(Model.HasError ? "nhsuk-form-group--error" : "")">
 
@@ -40,6 +44,7 @@
         <div class="nhsuk-radios" aria-required="@(Model.Required ? "true" : "false" )">
             @foreach (var (radio, index) in Model.Radios.Select((r, i) => (r, i)))
             {
+                counter = index;
                 var radioId = $"{radio.Value}-{index}";
                 if (!string.IsNullOrWhiteSpace(Model.Class))
                 {
@@ -90,6 +95,31 @@
                     </div>
                 }
 
+            }
+            @if(Model.OptionalRadio != null)
+            {
+                <div class="nhsuk-radios__divider nhsuk-u-padding-left-2">or</div>
+                var radioId = $"{Model.OptionalRadio.Value}-{++counter}";
+                <div class="nhsuk-radios__item">
+                    <input class="nhsuk-radios__input"
+                       id="@radioId"
+                       name="@Model.AspFor"
+                       type="radio"
+                       value="@Model.OptionalRadio.Value"
+                       aria-describedby="@Model.OptionalRadio.Value-item-hint"
+                       data-val-required="@(Model.Required ? Model.RequiredClientSideErrorMessage : "" )"
+                       data-val="@(Model.Required ? "true" : "false" )"
+                       @(Model.OptionalRadio.Selected ? "checked" : string.Empty) />
+                    <label class="nhsuk-label nhsuk-radios__label" for="@radioId">
+                        @Model.OptionalRadio.Label
+                    </label>
+                    @if (Model.OptionalRadio.HintText != null)
+                    {
+                        <div class="nhsuk-hint nhsuk-radios__hint" id="@Model.OptionalRadio.Value-item-hint">
+                            @Model.OptionalRadio.HintText
+                        </div>
+                    }
+                </div>
             }
 
         </div>


### PR DESCRIPTION

### JIRA link
[TD-1871](https://hee-tis.atlassian.net/browse/TD-1871)

### Description
- Extend NHSUK view component to accept a text divider(OR) while providing the name of the radio item to display after the text divider
- Allow Date Input label to be configured as page header.

### Screenshots
![DateInput1](https://github.com/TechnologyEnhancedLearning/NHSDesignSystemViewComponents/assets/114475132/d7f907aa-cbfa-4435-9205-76696dda797e)
![DateInput2](https://github.com/TechnologyEnhancedLearning/NHSDesignSystemViewComponents/assets/114475132/348d1115-7e34-496f-9f36-64c5597e07fc)
![DividerRadio](https://github.com/TechnologyEnhancedLearning/NHSDesignSystemViewComponents/assets/114475132/d0c32a10-fda4-4eef-97b7-1939414e892e)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1871]: https://hee-tis.atlassian.net/browse/TD-1871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ