### PR TITLE
TD1871 Radio and Date Input style update when view component is set as page header

### DIFF
--- a/NHSUKViewComponents.Web/ViewComponents/RadioListViewComponent.cs
+++ b/NHSUKViewComponents.Web/ViewComponents/RadioListViewComponent.cs
@@ -17,7 +17,8 @@
             bool required,
             string? requiredClientSideErrorMessage = default,
             string cssClass = default,
-            string? optionalRadio = default
+            string? optionalRadio = default,
+            bool? isPageHeading = false
         )
         {
             var model = ViewData.Model;
@@ -46,7 +47,8 @@
                 errorMessages,
                 required,
                 string.IsNullOrEmpty(requiredClientSideErrorMessage) ? null : requiredClientSideErrorMessage,
-                string.IsNullOrEmpty(cssClass) ? null : cssClass
+                string.IsNullOrEmpty(cssClass) ? null : cssClass,
+                isPageHeading
             );
 
             return View(viewModel);

--- a/NHSUKViewComponents.Web/ViewModels/RadiosViewModel.cs
+++ b/NHSUKViewComponents.Web/ViewModels/RadiosViewModel.cs
@@ -14,7 +14,8 @@
             IEnumerable<string> errorMessages,
             bool required,
             string? requiredClientSideErrorMessage = default,
-            string? cssClass = default
+            string? cssClass = default,
+            bool? isPageHeading = false
         )
         {
             var errorMessageList = errorMessages.ToList();
@@ -28,6 +29,7 @@
             Required = required;
             RequiredClientSideErrorMessage = requiredClientSideErrorMessage;
             Class = cssClass;
+            IsPageHeading = isPageHeading;
         }
 
         public string AspFor { get; set; }
@@ -41,6 +43,7 @@
 
         public IEnumerable<RadiosItemViewModel> Radios { get; set; }
         public RadiosItemViewModel OptionalRadio { get; set; }
+        public bool? IsPageHeading { get; set; }
         public bool Required { get; set; }
         public string RequiredClientSideErrorMessage { get; set; }
     }

--- a/NHSUKViewComponents.Web/Views/Shared/Components/DateInput/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/DateInput/Default.cshtml
@@ -10,19 +10,9 @@
 
 <div class="@Model.CssClass @errorCss" id="@Model.Id">
   <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Id-hint" role="group">
-        <legend class="nhsuk-fieldset__legend @(Model.IsPageHeading.GetValueOrDefault() ? "nhsuk-fieldset__legend--l":"nhsuk-label")">
-        @if(Model.IsPageHeading.GetValueOrDefault()==true)
-        {
-            <h1 class="nhsuk-fieldset__heading">
-                @Model.Label
-            </h1>
-        }
-        else
-        {
-              @Model.Label
-        }
-
-    </legend>
+        <legend class="@(Model.IsPageHeading.GetValueOrDefault() ? "nhsuk-heading-xl":"nhsuk-fieldset__legend nhsuk-label")">
+            @Model.Label
+        </legend>
     @if (Model.HintTextLines != null) {
       @foreach (var hintText in Model.HintTextLines) {
         <div class="nhsuk-hint">

--- a/NHSUKViewComponents.Web/Views/Shared/Components/DateInput/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/DateInput/Default.cshtml
@@ -10,9 +10,19 @@
 
 <div class="@Model.CssClass @errorCss" id="@Model.Id">
   <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Id-hint" role="group">
-        <legend class="@(Model.IsPageHeading.GetValueOrDefault() ? "nhsuk-heading-xl":"nhsuk-fieldset__legend nhsuk-label")">
-            @Model.Label
+        <legend class="nhsuk-fieldset__legend nhsuk-label">
+            @if (Model.IsPageHeading.GetValueOrDefault() == true)
+            {
+                <h1>
+                    @Model.Label
+                </h1>
+            }
+            else
+            {
+                @Model.Label
+            }
         </legend>
+        
     @if (Model.HintTextLines != null) {
       @foreach (var hintText in Model.HintTextLines) {
         <div class="nhsuk-hint">

--- a/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
@@ -11,7 +11,7 @@
 
     <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Label.RemoveWhitespace()-hint">
         <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
-            <label class="nhsuk-fieldset__heading">
+            <label class="@(Model.IsPageHeading.GetValueOrDefault() ? "nhsuk-heading-xl":"nhsuk-fieldset__heading")">
                 @Model.Label
             </label>
         </legend>

--- a/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
@@ -11,9 +11,18 @@
 
     <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Label.RemoveWhitespace()-hint">
         <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
-            <label class="@(Model.IsPageHeading.GetValueOrDefault() ? "nhsuk-heading-xl":"nhsuk-fieldset__heading")">
-                @Model.Label
-            </label>
+            @if (Model.IsPageHeading.GetValueOrDefault() == true)
+            {
+                <h1>
+                    @Model.Label
+                </h1>
+            }
+            else
+            {
+                <label class="nhsuk-fieldset__heading">
+                    @Model.Label
+                </label>
+            }
         </legend>
 
         @if (Model.HintText != null)


### PR DESCRIPTION
### JIRA link
[TD-1871](https://hee-tis.atlassian.net/browse/TD-1870)

### Description
when component is set as page heading, the component label is set as h1 with it's fieldset styling(nhsuk-fieldset__heading) relaxed in other to achieve the default H1 styles

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1871]: https://hee-tis.atlassian.net/browse/TD-1871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ