### PR TITLE
TD-1276: ordering of error  summary  list

### DIFF
--- a/NHSUKViewComponents.Web/Views/Shared/Components/ErrorSummary/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/ErrorSummary/Default.cshtml
@@ -1,22 +1,22 @@
 ﻿@using NHSUKViewComponents.Web.ViewModels
 @model ErrorSummaryViewModel
 
-@if(Model.Errors.Any())
+@if (Model.Errors.Any())
 {
     <div class="nhsuk-error-summary nhsuk-u-reading-width" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
-      <h2 class="nhsuk-error-summary__title" id="error-summary-title">
-        There is a problem
-      </h2>
-      <div class="nhsuk-error-summary__body">
-        <ul class="nhsuk-list nhsuk-error-summary__list">
-          @foreach (var item in Model.Errors.OrderBy(x=>x.Key))
-          {
-            <li>
-              <a href="#@item.Key">@item.ErrorMessage</a>
-            </li>
-          }
-        </ul>
-      </div>
+        <h2 class="nhsuk-error-summary__title" id="error-summary-title">
+            There is a problem
+        </h2>
+        <div class="nhsuk-error-summary__body">
+            <ul class="nhsuk-list nhsuk-error-summary__list">
+                @foreach (var item in Model.Errors.OrderBy(x => x.Key))
+                {
+                    <li>
+                        <a href="#@item.Key">@item.ErrorMessage</a>
+                    </li>
+                }
+            </ul>
+        </div>
     </div>
 }
 else

--- a/NHSUKViewComponents.Web/Views/Shared/Components/ErrorSummary/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/ErrorSummary/Default.cshtml
@@ -9,7 +9,7 @@
       </h2>
       <div class="nhsuk-error-summary__body">
         <ul class="nhsuk-list nhsuk-error-summary__list">
-          @foreach (var item in Model.Errors)
+          @foreach (var item in Model.Errors.OrderBy(x=>x.Key))
           {
             <li>
               <a href="#@item.Key">@item.ErrorMessage</a>


### PR DESCRIPTION
### JIRA link
[TD-1276](https://hee-tis.atlassian.net/browse/TD-2176)

### Description
This display of error summary list is modified to display in ascending order(alphabetically)

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/NHSDesignSystemViewComponents/assets/114475132/ee49d3af-326c-41b1-a097-1981da4ba426)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-1276]: https://hee-tis.atlassian.net/browse/TD-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ