### PR TITLE
TD-2217 accessibility fix for radio field-set and date input

### DIFF
--- a/NHSUKViewComponents.Web/Views/Shared/Components/DateInput/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/DateInput/Default.cshtml
@@ -25,7 +25,7 @@
         
     @if (Model.HintTextLines != null) {
       @foreach (var hintText in Model.HintTextLines) {
-        <div class="nhsuk-hint">
+        <div class="nhsuk-hint" id="@Model.Id-hint">
           @hintText
         </div>
       }

--- a/NHSUKViewComponents.Web/Views/Shared/Components/ErrorSummary/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/ErrorSummary/Default.cshtml
@@ -11,9 +11,12 @@
             <ul class="nhsuk-list nhsuk-error-summary__list">
                 @foreach (var item in Model.Errors.OrderBy(x => x.Key))
                 {
-                    <li>
-                        <a href="#@item.Key">@item.ErrorMessage</a>
-                    </li>
+                    if (!string.IsNullOrWhiteSpace(item.ErrorMessage))
+                    {
+                        <li>
+                            <a href="#@item.Key">@item.ErrorMessage</a>
+                        </li>
+                    }  
                 }
             </ul>
         </div>

--- a/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
@@ -9,7 +9,7 @@
 
 <div class="nhsuk-form-group @(Model.HasError ? "nhsuk-form-group--error" : "")">
 
-    <fieldset class="nhsuk-fieldset" aria-describedby="@Model.Label.RemoveWhitespace()-hint">
+    <fieldset class="nhsuk-fieldset" aria-describedby="@(!string.IsNullOrEmpty(Model.HintText) ? $"{Model.Label.RemoveWhitespace()}-hint" : string.Empty)">
         <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
             @if (Model.IsPageHeading.GetValueOrDefault() == true)
             {


### PR DESCRIPTION
### JIRA link
[TD-2217](https://hee-tis.atlassian.net/browse/TD-2217)

### Description

- Fix field-set accessibility issue when hint text is empty
- Fix for date-input accessibility issue when hint text is empty
- Display error summary only when error message is not empty

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2217]: https://hee-tis.atlassian.net/browse/TD-2217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ