### PR TITLE
TD-2191 Removal of aria-required attribute  from the radio list viewcomponent

### DIFF
--- a/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
@@ -50,7 +50,7 @@
             </div>
         }
 
-        <div class="nhsuk-radios" aria-required="@(Model.Required ? "true" : "false" )">
+        <div class="nhsuk-radios">
             @foreach (var (radio, index) in Model.Radios.Select((r, i) => (r, i)))
             {
                 counter = index;


### PR DESCRIPTION

### JIRA link
[TD-2191](https://hee-tis.atlassian.net/browse/TD-2191)

### Description
The aria-required attribute isn't valid for a radio button .This was highlighted by the aXe accessibility test plugin.
The rules guiding the use of aria for  radio button doesn't contain aria-required based on the link below
[MDN_Radio](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role) and  [W3_Radio](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio-rating/)

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-2191]: https://hee-tis.atlassian.net/browse/TD-2191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ