### PR TITLE
Update continuous-integration-workflow.yml

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -17,16 +17,16 @@ jobs:
           with:
            fetch-depth: 0
 
-        - name: Setup .NET Core SDK 60
-          uses: actions/setup-dotnet@v1
-          with:
-            dotnet-version: ${{ matrix.dotnet-version }}
-
         - name: Install ICU library
           run: sudo apt-get update && sudo apt-get install -y libicu-dev
 
         - name: Enable Invariant Globalization
           run: echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1" >> $GITHUB_ENV
+
+        - name: Setup .NET Core SDK 60
+          uses: actions/setup-dotnet@v1
+          with:
+            dotnet-version: ${{ matrix.dotnet-version }}
 
         - name: Install GitVersion
           uses: gittools/actions/gitversion/setup@v0.9.7

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -6,7 +6,7 @@ jobs:
         BUILD_CONFIG: 'Release'
         SOLUTION: 'NHSUKViewComponents.sln'
       name: Build and publish package
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04 
       permissions:
           packages: write
       strategy: 
@@ -19,14 +19,6 @@ jobs:
 
         - name: Install ICU library
           run: sudo apt-get update && sudo apt-get install -y libicu-dev
-
-        - name: Install libssl1.1 manually
-          run: |
-            wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
-            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
-
-        - name: Enable Invariant Globalization
-          run: echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1" >> $GITHUB_ENV
 
         - name: Setup .NET Core SDK 60
           uses: actions/setup-dotnet@v1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -22,6 +22,9 @@ jobs:
           with:
             dotnet-version: ${{ matrix.dotnet-version }}
 
+        - name: Install ICU library
+          run: sudo apt-get update && sudo apt-get install -y libicu-dev
+
         - name: Install GitVersion
           uses: gittools/actions/gitversion/setup@v0.9.7
           with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -25,6 +25,9 @@ jobs:
         - name: Install ICU library
           run: sudo apt-get update && sudo apt-get install -y libicu-dev
 
+        - name: Enable Invariant Globalization
+          run: echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1" >> $GITHUB_ENV
+
         - name: Install GitVersion
           uses: gittools/actions/gitversion/setup@v0.9.7
           with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,6 +20,11 @@ jobs:
         - name: Install ICU library
           run: sudo apt-get update && sudo apt-get install -y libicu-dev
 
+        - name: Install required libssl version
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y libssl1.1
+
         - name: Enable Invariant Globalization
           run: echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1" >> $GITHUB_ENV
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,10 +20,10 @@ jobs:
         - name: Install ICU library
           run: sudo apt-get update && sudo apt-get install -y libicu-dev
 
-        - name: Install required libssl version
+        - name: Install libssl1.1 manually
           run: |
-            sudo apt-get update
-            sudo apt-get install -y libssl1.1
+            wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
+            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
 
         - name: Enable Invariant Globalization
           run: echo "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1" >> $GITHUB_ENV


### PR DESCRIPTION
### JIRA link
Github action build issue

### Description
ICU (International Components for Unicode) is missing on the ubuntu-latest GitHub Actions runner. The ICU package is necessary for globalization support when running .NET Core applications. 


### Screenshots
![image](https://github.com/user-attachments/assets/e6f627d0-14fa-41c7-987c-52c5d25e3f9f)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
