### PR TITLE
TD-4180 update to set focus on the first item of a radio group

### DIFF
--- a/NHSUKViewComponents.Web/ViewComponents/ErrorSummaryViewComponent.cs
+++ b/NHSUKViewComponents.Web/ViewComponents/ErrorSummaryViewComponent.cs
@@ -13,9 +13,23 @@
                 .SelectMany(kvp => kvp.Value.Errors.Select(e => new ErrorSummaryListItem(kvp.Key, e.ErrorMessage)))
                 .ToList();
 
+            var groupingMetadata = ViewData["GroupedFormControlMetadata"] as Dictionary<string, bool>;
+
+            foreach (var error in errors)
+            {
+                string key = error.Key;
+                bool isGrouped = groupingMetadata != null && groupingMetadata.ContainsKey(key) && groupingMetadata[key];
+
+                if (isGrouped)
+                {
+                    error.Key += "-0";
+                }
+            }
+
             var orderedErrors = GetOrderedErrors(errors, orderOfPropertyNames ?? new string[0]);
 
             var errorSummaryViewModel = new ErrorSummaryViewModel(orderedErrors);
+
             return View(errorSummaryViewModel);
         }
 

--- a/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
+++ b/NHSUKViewComponents.Web/Views/Shared/Components/RadioList/Default.cshtml
@@ -52,7 +52,7 @@
             @foreach (var (radio, index) in Model.Radios.Select((r, i) => (r, i)))
             {
                 counter = index;
-                var radioId = $"{radio.Value}-{index}";
+                var radioId = $"{Model.AspFor}-{index}";
                 if (!string.IsNullOrWhiteSpace(Model.Class))
                 {
                     <div class="@Model.Class">
@@ -106,7 +106,7 @@
             @if (Model.OptionalRadio != null)
             {
                 <div class="nhsuk-radios__divider nhsuk-u-padding-left-2">or</div>
-                var radioId = $"{Model.OptionalRadio.Value}-{++counter}";
+                var radioId = $"{Model.AspFor}-{++counter}";
                 <div class="nhsuk-radios__item">
                     <input class="nhsuk-radios__input"
                            id="@radioId"


### PR DESCRIPTION
### JIRA link
[TD-4180 ](https://hee-tis.atlassian.net/browse/TD-4180)

### Description
namining convention for radio group has been updated.
Error summary can now target or set focus on specific elements

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
